### PR TITLE
if the asr times are the same, don't show it

### DIFF
--- a/components/PrayerTimes/PrayerTimes.tsx
+++ b/components/PrayerTimes/PrayerTimes.tsx
@@ -88,7 +88,7 @@ export default function PrayerTimes({
               </th>
               <td className="text-xl md:text-6xl">
                 {dtFormatTimeTo12h(prayer.data.start)}
-                {prayer.data?.start_secondary ? (
+                {prayer.data?.start_secondary && (prayer.data.start !== prayer.data.start_secondary) ? (
                   <div className="block mt-1 md:mt-2">
                     {dtFormatTimeTo12h(prayer.data.start_secondary)}
                   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected prayer time display logic to prevent duplicate times from appearing when secondary and primary values are identical, improving clarity in the prayer schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->